### PR TITLE
Set MainWindow dimensions on start as a percentage of desktip dimensions

### DIFF
--- a/source/view/include/mainwindow.hpp
+++ b/source/view/include/mainwindow.hpp
@@ -27,6 +27,9 @@ signals:
     void playlistAddRequested(const QString &title);
 
 private:
+    // Percentage of desktop dimensions that MainWindow will assume
+    static const double windowPercentageOfDesktop;
+
     DeletableListView *playlistContainer, *songListView;
     PlayerView *playerView;
     QLineEdit *newPlaylistTextEdit;

--- a/source/view/mainwindow.cpp
+++ b/source/view/mainwindow.cpp
@@ -4,6 +4,10 @@
 #include <QVBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QApplication>
+#include <QDesktopWidget>
+
+const double MainWindow::windowPercentageOfDesktop = 0.6;
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -44,6 +48,11 @@ void MainWindow::setupWindow()
 {
     this->setWindowTitle(QString("Spotify Desktop"));
     this->setCentralWidget(new QWidget());
+
+    setGeometry(QApplication::desktop()->size().width() * (1.0 - windowPercentageOfDesktop) / 2.0,
+                QApplication::desktop()->size().height() * (1.0 - windowPercentageOfDesktop) / 2.0,
+                QApplication::desktop()->size().width() * windowPercentageOfDesktop,
+                QApplication::desktop()->size().height() * windowPercentageOfDesktop);
 }
 
 void MainWindow::setupWidgets()


### PR DESCRIPTION
Improving MainWindow to start up with a good dimension related to desktop dimesion.