### PR TITLE
Feature/refactoring database classes

### DIFF
--- a/qtcreator/SpotifyDesktopFrontend.pro
+++ b/qtcreator/SpotifyDesktopFrontend.pro
@@ -32,6 +32,7 @@ SOURCES += \
     $$SOURCEPATH/view/deletablelistview.cpp \
     $$SOURCEPATH/view/deletableitem.cpp \
     $$SOURCEPATH/view/playerview.cpp \
+    $$SOURCEPATH/model/database/database.cpp \
     $$SOURCEPATH/model/database/playlisttable.cpp \
     $$SOURCEPATH/model/database/songtable.cpp \
     $$SOURCEPATH/model/network/spotifyapicredentials.cpp \
@@ -46,6 +47,7 @@ HEADERS += \
     $$SOURCEPATH/view/include/deletablelistview.hpp \
     $$SOURCEPATH/view/include/deletableitem.hpp \
     $$SOURCEPATH/view/include/playerview.hpp \
+    $$SOURCEPATH/model/database/include/database.hpp \
     $$SOURCEPATH/model/database/include/playlisttable.hpp \
     $$SOURCEPATH/model/database/include/songtable.hpp \
     $$SOURCEPATH/model/network/include/spotifyapicredentials.hpp \

--- a/source/core.cpp
+++ b/source/core.cpp
@@ -9,16 +9,8 @@
 
 QMutex Core::runMutex;
 
-const QString Core::databaseDriver("QSQLITE");
-const QString Core::databaseName("db.dat");
-
 QString Core::errorMsgTitle;
 QString Core::errorMsg;
-
-Core::~Core()
-{
-    database.close();
-}
 
 int Core::run(QApplication &app)
 {

--- a/source/core.cpp
+++ b/source/core.cpp
@@ -34,7 +34,7 @@ int Core::run(QApplication &app)
         bool appInitializationFailed = false;
         Core core(app);
 
-        if(!core.connectToDatabase())
+        if(!core.database.open())
             appInitializationFailed = true;
 
         core.initControllers();
@@ -58,16 +58,19 @@ int Core::run(QApplication &app)
     }
 }
 
-Core::Core(QApplication &app) :
-    app(app),
-    mainWindow(MainWindow::getInstance())
-{
-}
-
 void Core::setErrorDialog(const QString &title, const QString &msg)
 {
     errorMsgTitle = title;
     errorMsg = msg;
+}
+
+Core::Core(QApplication &app) :
+    app(app),
+    database(Database::getInstance()),
+    mainWindow(MainWindow::getInstance())
+{
+    connect(&database, SIGNAL(errorMsgSent(const QString&, const QString&)),
+            this, SLOT(setErrorDialog(const QString&, const QString&)));
 }
 
 int Core::exec()
@@ -77,82 +80,10 @@ int Core::exec()
     return app.exec();
 }
 
-bool Core::connectToDatabase()
-{
-    bool mustCreateSchema = !QFileInfo::exists(databaseName);
-
-    database = QSqlDatabase::addDatabase(databaseDriver);
-    database.setDatabaseName(databaseName);
-
-    if(database.open())
-    {
-        if(mustCreateSchema)
-        {
-            if(!createDatabaseSchema())
-            {
-                setErrorDialog("Database query error",
-                               "Error while creating database tables");
-
-                return false;
-            }
-        }
-
-        return true;
-    }
-    else
-    {
-        qDebug() << "Database error: " << database.lastError();
-
-        setErrorDialog("Cannot open database", "Unable to establish a database connection");
-
-        return false;
-    }
-}
-
-bool Core::createDatabaseSchema()
-{
-    QSqlQuery query(database);
-    bool success = true;
-
-    qDebug() << "<Core::createDatabaseSchema>";
-
-    if(!query.exec("CREATE TABLE PLAYLIST("
-                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                    "NAME VARCHAR(100) UNIQUE)"))
-    {
-        qDebug() << query.lastError();
-        success = false;
-    }
-
-    if(!query.exec("CREATE TABLE SONG("
-                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                    "NAME VARCHAR(100),"
-                    "PLAYLIST_ID INTEGER,"
-                    "SPOTIFY_ID VARCHAR(100),"
-                    "SPOTIFY_URI VARCHAR(100),"
-                    "FOREIGN KEY(PLAYLIST_ID) REFERENCES PLAYLIST(ID))"))
-    {
-        qDebug() << query.lastError();
-        success = false;
-    }
-
-    if(!query.exec("CREATE TABLE CREDENTIALS("
-                    "LOGIN VARCHAR(30) PRIMARY KEY,"
-                    "PASSWORD VARCHAR(30))"))
-    {
-        qDebug() << query.lastError();
-        success = false;
-    }
-
-    qDebug() << "</Core::dataBaseSchema>";
-
-    return success;
-}
-
 void Core::initControllers()
 {
-    playlistController = new PlaylistController(database, this);
-    songListController = new SongListController(database, this);
+    playlistController = new PlaylistController(database.getDbObject(), this);
+    songListController = new SongListController(database.getDbObject(), this);
     spotifWebApiController = new SpotifyWebApiController(this);
 }
 

--- a/source/include/core.hpp
+++ b/source/include/core.hpp
@@ -21,8 +21,6 @@ public:
     static const int CORE_ALREADY_RUNNING = -1;
     static QMutex runMutex;
 
-    ~Core();
-
     static int run(QApplication &app);
 
     Core(Core const &) = delete;
@@ -36,8 +34,6 @@ public slots:
     void setErrorDialog(const QString &title, const QString &msg);
 
 private:
-    static const QString databaseDriver;
-    static const QString databaseName;
     static QString errorMsgTitle, errorMsg;
 
     QApplication &app;

--- a/source/include/core.hpp
+++ b/source/include/core.hpp
@@ -6,6 +6,8 @@
 #include "songlistcontroller.hpp"
 #include "spotifywebapicontroller.hpp"
 
+#include "database.hpp"
+
 #include <QApplication>
 #include <QMutex>
 #include <QObject>
@@ -30,13 +32,16 @@ signals:
     void mustLoadAppData();
     void mustStartNetwork();
 
+public slots:
+    void setErrorDialog(const QString &title, const QString &msg);
+
 private:
     static const QString databaseDriver;
     static const QString databaseName;
     static QString errorMsgTitle, errorMsg;
 
     QApplication &app;
-    QSqlDatabase database;
+    Database &database;
 
     MainWindow &mainWindow;
 
@@ -46,12 +51,8 @@ private:
 
     Core(QApplication &app);
 
-    static void setErrorDialog(const QString &title, const QString &msg);
-
     int exec();
 
-    bool connectToDatabase();
-    bool createDatabaseSchema();
     void initControllers();
     void bindMVC();
     void sendLoadAppSignal();

--- a/source/model/database/database.cpp
+++ b/source/model/database/database.cpp
@@ -1,0 +1,100 @@
+#include "database.hpp"
+
+#include <QDebug>
+#include <QFileInfo>
+#include <QSqlError>
+#include <QSqlQuery>
+
+const QString Database::databaseDriver("QSQLITE");
+const QString Database::databaseName("db.dat");
+
+Database::~Database()
+{
+    database.close();
+}
+
+Database &Database::getInstance()
+{
+    static Database instance;
+
+    return instance;
+}
+
+QSqlDatabase &Database::getDbObject()
+{
+    return database;
+}
+
+bool Database::open()
+{
+    bool mustCreateSchema = !QFileInfo::exists(databaseName);
+
+    database = QSqlDatabase::addDatabase(databaseDriver);
+    database.setDatabaseName(databaseName);
+
+    if(database.open())
+    {
+        if(mustCreateSchema)
+        {
+            if(!createSchema())
+            {
+                emit errorMsgSent("Database query error",
+                                  "Error while creating database tables");
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+    else
+    {
+        qDebug() << "Database error: " << database.lastError();
+
+        emit errorMsgSent("Cannot open database",
+                          "Unable to establish a database connection");
+
+        return false;
+    }
+}
+
+void Database::close()
+{
+    database.close();
+}
+
+Database::Database()
+{
+}
+
+bool Database::createSchema()
+{
+    QSqlQuery query(database);
+    bool success = true;
+
+    qDebug() << "<Core::createDatabaseSchema>";
+
+    if(!query.exec("CREATE TABLE PLAYLIST("
+                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "NAME VARCHAR(100) UNIQUE)"))
+    {
+        qDebug() << query.lastError();
+        success = false;
+    }
+
+    if(!query.exec("CREATE TABLE SONG("
+                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "NAME VARCHAR(100),"
+                    "PLAYLIST_ID INTEGER,"
+                    "SPOTIFY_ID VARCHAR(100),"
+                    "SPOTIFY_URI VARCHAR(100),"
+                    "FOREIGN KEY(PLAYLIST_ID) REFERENCES PLAYLIST(ID))"))
+    {
+        qDebug() << query.lastError();
+        success = false;
+    }
+
+    qDebug() << "</Core::dataBaseSchema>";
+
+    return success;
+}

--- a/source/model/database/include/database.hpp
+++ b/source/model/database/include/database.hpp
@@ -1,0 +1,39 @@
+#ifndef DATABASE_HPP
+#define DATABASE_HPP
+
+#include <QObject>
+#include <QSqlDatabase>
+#include <QString>
+
+class Database : public QObject
+{
+    Q_OBJECT
+
+public:
+    ~Database();
+
+    static Database& getInstance();
+
+    Database(Database const &) = delete;
+    void operator = (Database const &) = delete;
+
+    QSqlDatabase& getDbObject();
+
+    bool open();
+    void close();
+
+signals:
+    void errorMsgSent(const QString&, const QString&);
+
+private:
+    static const QString databaseDriver;
+    static const QString databaseName;
+
+    QSqlDatabase database;
+
+    Database();
+
+    bool createSchema();
+};
+
+#endif // DATABASE_HPP

--- a/source/model/database/include/playlisttable.hpp
+++ b/source/model/database/include/playlisttable.hpp
@@ -13,6 +13,7 @@ class PlaylistTable : public QObject
     Q_OBJECT
 
 public:
+    static const QString TABLE_NAME;
     static const QString ID_FIELD;
     static const QString NAME_FIELD;
 

--- a/source/model/database/include/songtable.hpp
+++ b/source/model/database/include/songtable.hpp
@@ -13,8 +13,13 @@ class SongTable : public QObject
     Q_OBJECT
 
 public:
+    static const QString TABLE_NAME;
     static const QString ID_FIELD;
     static const QString NAME_FIELD;
+    static const QString PLAYLIST_ID;
+    static const QString SPOTIFY_ID;
+    static const QString SPOTIFY_URI;
+
 
     class Tuple
     {

--- a/source/model/database/playlisttable.cpp
+++ b/source/model/database/playlisttable.cpp
@@ -4,6 +4,7 @@
 #include <QSqlRecord>
 #include <QVariant>
 
+const QString PlaylistTable::TABLE_NAME("PLAYLIST");
 const QString PlaylistTable::ID_FIELD("ID");
 const QString PlaylistTable::NAME_FIELD("NAME");
 

--- a/source/model/database/playlisttable.cpp
+++ b/source/model/database/playlisttable.cpp
@@ -15,7 +15,11 @@ PlaylistTable::PlaylistTable(QSqlDatabase &database) :
 
 list<PlaylistTable::Tuple> PlaylistTable::getAllPlaylists()
 {
-    QSqlQuery query("SELECT ID, NAME FROM PLAYLIST", database);
+    QSqlQuery query(database);
+    query.prepare("SELECT ?, ? FROM ?");
+    query.bindValue(0, ID_FIELD);
+    query.bindValue(1, NAME_FIELD);
+    query.bindValue(2, TABLE_NAME);
     int idFieldNum = query.record().indexOf(ID_FIELD);
     int nameFieldNum = query.record().indexOf(NAME_FIELD);
     list<Tuple> listOfPlaylists;
@@ -34,8 +38,10 @@ list<PlaylistTable::Tuple> PlaylistTable::getAllPlaylists()
 void PlaylistTable::insert(const QString &title)
 {
     QSqlQuery query(database);
-    query.prepare("INSERT INTO PLAYLIST (NAME) VALUES (?)");
-    query.bindValue(0, title);
+    query.prepare("INSERT INTO ? (?) VALUES (?)");
+    query.bindValue(0, TABLE_NAME);
+    query.bindValue(1, NAME_FIELD);
+    query.bindValue(2, title);
 
     if(query.exec())
         emit playlistInserted(title, query.lastInsertId().toInt());
@@ -46,8 +52,10 @@ void PlaylistTable::insert(const QString &title)
 void PlaylistTable::remove(int id)
 {
     QSqlQuery query(database);
-    query.prepare("DELETE FROM PLAYLIST WHERE ID = ?");
-    query.bindValue(0, id);
+    query.prepare("DELETE FROM ? WHERE ? = ?");
+    query.bindValue(0, TABLE_NAME);
+    query.bindValue(1, ID_FIELD);
+    query.bindValue(2, id);
 
     if(query.exec())
         emit playlistRemoved(id);

--- a/source/model/database/playlisttable.cpp
+++ b/source/model/database/playlisttable.cpp
@@ -1,5 +1,7 @@
 #include "playlisttable.hpp"
 
+#include <QDebug>
+#include <QSqlError>
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QVariant>
@@ -15,14 +17,14 @@ PlaylistTable::PlaylistTable(QSqlDatabase &database) :
 
 list<PlaylistTable::Tuple> PlaylistTable::getAllPlaylists()
 {
-    QSqlQuery query(database);
-    query.prepare("SELECT ?, ? FROM ?");
-    query.bindValue(0, ID_FIELD);
-    query.bindValue(1, NAME_FIELD);
-    query.bindValue(2, TABLE_NAME);
+    QSqlQuery query(QString("SELECT ") + ID_FIELD + ", " + NAME_FIELD + " FROM "+ TABLE_NAME,
+                    database);
     int idFieldNum = query.record().indexOf(ID_FIELD);
     int nameFieldNum = query.record().indexOf(NAME_FIELD);
     list<Tuple> listOfPlaylists;
+
+    qDebug() << "<PlaylistTable::getAllPlaylists>";
+    qDebug() << "Query:" << query.lastQuery();
 
     while(query.next())
     {
@@ -32,33 +34,44 @@ list<PlaylistTable::Tuple> PlaylistTable::getAllPlaylists()
         listOfPlaylists.push_back(Tuple(id, name));
     }
 
+    qDebug() << "Query exec result:" << query.lastError();
+    qDebug() << "</PlaylistTable::getAllPlaylists>";
+
     return listOfPlaylists;
 }
 
 void PlaylistTable::insert(const QString &title)
 {
     QSqlQuery query(database);
-    query.prepare("INSERT INTO ? (?) VALUES (?)");
-    query.bindValue(0, TABLE_NAME);
-    query.bindValue(1, NAME_FIELD);
-    query.bindValue(2, title);
+    query.prepare(QString("INSERT INTO ") + TABLE_NAME + "(" + NAME_FIELD + ")" + " VALUES (?)");
+    query.bindValue(0, title);
+
+    qDebug() << "<PlaylistTable::insert title =" << title << ">";
 
     if(query.exec())
         emit playlistInserted(title, query.lastInsertId().toInt());
     else
         emit insertionFailed(title);
+
+    qDebug() << "Query:" << query.lastQuery();
+    qDebug() << "Query exec result:" << query.lastError();
+    qDebug() << "</PlaylistTable::insert>";
 }
 
 void PlaylistTable::remove(int id)
 {
     QSqlQuery query(database);
-    query.prepare("DELETE FROM ? WHERE ? = ?");
-    query.bindValue(0, TABLE_NAME);
-    query.bindValue(1, ID_FIELD);
-    query.bindValue(2, id);
+    query.prepare(QString("DELETE FROM ") + TABLE_NAME + " WHERE " + ID_FIELD + " = ?");
+    query.bindValue(0, id);
+
+    qDebug() << "<PlaylistTable::remove id =" << id << ">";
+    qDebug() << "Query:" << query.lastQuery();
 
     if(query.exec())
         emit playlistRemoved(id);
+
+    qDebug() << "Query exec result:" << query.lastError();
+    qDebug() << "</PlaylistTable::remove>";
 }
 
 PlaylistTable::Tuple::Tuple(int id, const QString name) :

--- a/source/model/database/songtable.cpp
+++ b/source/model/database/songtable.cpp
@@ -7,8 +7,12 @@
 #include <QSqlRecord>
 #include <QVariant>
 
+const QString SongTable::TABLE_NAME("SONG");
 const QString SongTable::ID_FIELD("ID");
 const QString SongTable::NAME_FIELD("NAME");
+const QString SongTable::PLAYLIST_ID("PLAYLIST_ID");
+const QString SongTable::SPOTIFY_ID("SPOTIFY_ID");
+const QString SongTable::SPOTIFY_URI("SPOTIFY_URI");
 
 SongTable::SongTable(QSqlDatabase &database, QObject *parent) :
     QObject(parent),
@@ -23,7 +27,8 @@ list<SongTable::Tuple> SongTable::getPlaylist(int playlistID)
 
     qDebug() << "<SongTable::getPlaylist playlistID = " << playlistID << ">";
 
-    query.prepare("SELECT ID, NAME FROM SONG WHERE PLAYLIST_ID = ?");
+    query.prepare(QString("SELECT ") + ID_FIELD + ", " + NAME_FIELD + " FROM " +
+                  TABLE_NAME + " WHERE " + PLAYLIST_ID + " = ?");
     query.bindValue(0, playlistID);
 
     if(!query.exec())
@@ -57,7 +62,9 @@ void SongTable::insert(const QString &title,
                        const QString &spotifyUri)
 {
     QSqlQuery query(database);
-    query.prepare("INSERT INTO SONG (NAME, PLAYLIST_ID, SPOTIFY_ID, SPOTIFY_URI) "
+    query.prepare(QString("INSERT INTO ") + TABLE_NAME +
+                  " (" + NAME_FIELD + ", " + PLAYLIST_ID + ", " +
+                  SPOTIFY_ID + ", " + SPOTIFY_URI + ") " +
                   "VALUES (?, ?, ?, ?)");
     query.bindValue(0, title);
     query.bindValue(1, playlistID);
@@ -87,7 +94,7 @@ void SongTable::insert(const QString &title,
 void SongTable::remove(int id)
 {
     QSqlQuery query(database);
-    query.prepare("DELETE FROM SONG WHERE ID = ?");
+    query.prepare(QString("DELETE FROM ") + TABLE_NAME + " WHERE " + ID_FIELD + " = ?");
     query.bindValue(0, id);
 
     if(query.exec())


### PR DESCRIPTION
Refactoring some model classes to avoid table name, fields etc being hardcoded ina string. Now these values are concentrated in a single place in the class, if database schema changes, it will be easier to change the code (yet not perfect, but better than before). I coudln't make it cleaner because I couldn't get QSqlQuery to bind fields and table names properly to the query, so the solution was using QString